### PR TITLE
Cr 1557 fix with gsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 Cucumber acceptance tests for the Census Integration team's Field Service.
 
 The Field Service is designed to use the SAML authentication and authorisation to protect
-it primary endpoint, and the SAML IDP (Identity Provider) of choice is Google GSuite. 
+it primary endpoint, and the SAML IDP (Identity Provider) of choice is Google GSuite.
+
 
 For automated Cucumber tests in the GCP environment, Google GSuite IDP will present Captcha pages
-which makes the cucumber tests extremely difficult or impossible to write. For this reason, this 
+which makes the cucumber tests extremely difficult or impossible to write. For this reason, this
 project can be configured to run against an alternative IDP provider that does not present a Captcha challenge.
 
 ## Prerequisites
 
-* RabbitMQ must be running on port 35672. For running locally, see [RH Service README](https://github.com/ONSdigital/census-rh-service) for 
+* RabbitMQ must be running on port 35672. For running locally, see [RH Service README](https://github.com/ONSdigital/census-rh-service) for
   a description of how to get RabbitMQ running locally using `docker-compose`.
 * The [Mock Case API Service](https://github.com/ONSdigital/census-mock-case-api-service)  must be running.
 * The [Field Service](https://github.com/ONSdigital/census-field-service) must be running. See the README to ensure the selected profile,

--- a/src/test/java/uk/gov/ons/ctp/integration/fieldsvccucumber/steps/TestSSOFieldService.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/fieldsvccucumber/steps/TestSSOFieldService.java
@@ -139,9 +139,7 @@ public class TestSSOFieldService {
       log.info("*******HERE IS THE PAGE SOURCE END********");
     }
     log.with(currentURL).info("The current URL to check");
-    log.info(
-        "We need to assert that it tried to open the EQ page but that page does not exist i.e. that the current URL contains both the word 'session' and the word 'token'");
-    assertTrue(currentURL.contains("session") && currentURL.contains("token"));
+    assertTrue(currentURL.contains("?token"));
   }
 
   private boolean isEqHostUrl(String url) {


### PR DESCRIPTION
We no longer expect the EQ launch URL to contain the "/session" part.